### PR TITLE
낙관적 락으로 좋아용 구현

### DIFF
--- a/src/main/java/com/sns/modeling/application/controller/PostController.java
+++ b/src/main/java/com/sns/modeling/application/controller/PostController.java
@@ -86,8 +86,13 @@ public class PostController {
         return this.getTimelinePostUseCase.executeByTimeline(memberId, cursorRequest);
     }
 
+//    @PostMapping("/{postId}/like")
+//    public void likePost(@PathVariable Long postId){
+//        this.postWriteService.likePost(postId);
+//    }
+
     @PostMapping("/{postId}/like")
-    public void likePost(@PathVariable Long postId){
-        this.postWriteService.likePost(postId);
+    public void likePostOptimistic(@PathVariable Long postId){
+        this.postWriteService.likePostByOptimisticLock(postId);
     }
 }

--- a/src/main/java/com/sns/modeling/domain/post/entity/Post.java
+++ b/src/main/java/com/sns/modeling/domain/post/entity/Post.java
@@ -14,6 +14,7 @@ public class Post {
     final private String contents;
     final private LocalDate createdDate;
     private Long likeCount;
+    private Long version;
     final private LocalDateTime createdAt;
 
     @Builder
@@ -22,13 +23,16 @@ public class Post {
                 String contents,
                 LocalDate createdDate,
                 Long likeCount,
+                Long version,
                 LocalDateTime createdAt) {
         this.id = id;
         this.memberId = Objects.requireNonNull(memberId);
         this.contents = Objects.requireNonNull(contents);
         this.createdDate = createdDate == null ? LocalDate.now() : createdDate;
         this.likeCount = likeCount == null ? 0 : likeCount;
+        this.version = version == null ? 0 : version;
         this.createdAt = createdAt == null ? LocalDateTime.now() : createdAt;
+
     }
     public void incrementLikeCount(){
         this.likeCount += 1;

--- a/src/main/java/com/sns/modeling/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/sns/modeling/domain/post/repository/PostRepository.java
@@ -37,6 +37,7 @@ public class PostRepository {
             .createdDate(resultSet.getObject("createdDate", LocalDate.class))
             .createdAt(resultSet.getObject("createdAt", LocalDateTime.class))
             .likeCount(resultSet.getLong("likeCount"))
+            .version(resultSet.getLong("version"))
             .build();
 
     final static private RowMapper<DailyPostCount> DAILY_POST_COUNT_MAPPER = (ResultSet resultSet, int rowNum) -> new DailyPostCount(
@@ -229,11 +230,15 @@ public class PostRepository {
                                          contents = :contents,
                                          createdDate = :createdDate,
                                         likeCount = :likeCount,
-                                        createdAt = :createdAt
-                                        WHERE id  = :id
+                                        createdAt = :createdAt,
+                                        version = :version + 1
+                                        WHERE id  = :id and version = :version
                                          """, this.TABLE);
         SqlParameterSource params = new BeanPropertySqlParameterSource(post);
-        this.namedParameterJdbcTemplate.update(sql, params);
+        var updatedCount = this.namedParameterJdbcTemplate.update(sql, params);
+        if(updatedCount == 0){
+            throw new RuntimeException("갱신 실패");
+        }
         return post;
     }
 }

--- a/src/main/java/com/sns/modeling/domain/post/service/PostWriteService.java
+++ b/src/main/java/com/sns/modeling/domain/post/service/PostWriteService.java
@@ -5,6 +5,7 @@ import com.sns.modeling.domain.post.entity.Post;
 import com.sns.modeling.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,8 +21,23 @@ public class PostWriteService {
         return postRepository.save(post).getId();
     }
 
+    /**
+     *  트랜잭션도 열고, requiredLock(For Update) 과 Commit도 찍어야 하니
+     *  성능적으로는 Optimistic Lock이 더 좋다(심지어 각각 다른 트랜잭션으로 동작 된다.)
+     *  실제 실무에서 Optimistic Lock을 부담없이 사용한다.(JPA에서 @OptimisticLock 으로 쉽게 구현가능하다./ 그리고 두개의 Lock을 섞어서 사용 되기도 한다.)
+     *  하지만 분산 환경으로 가게 되면 비관적락을 간단하게 사용할수 없다.(로직에서 실수가 일어 날수있다.)
+     *  그래서 Optimistic Lock 추가적으로 적용해서 개발한다.
+     */
+
+    @Transactional
     public void likePost(Long postId){
         var post = this.postRepository.findById(postId, true).orElseThrow();
+        post.incrementLikeCount();
+        this.postRepository.save(post);
+    }
+
+    public void likePostByOptimisticLock(Long postId){
+        var post = this.postRepository.findById(postId, false).orElseThrow();
         post.incrementLikeCount();
         this.postRepository.save(post);
     }


### PR DESCRIPTION
트랜잭션도 열고, requiredLock(For Update) 과 Commit도 찍어야 하니
성능적으로는 Optimistic Lock이 더 좋다(심지어 각각 다른 트랜잭션으로 동작 된다.)
실제 실무에서 Optimistic Lock을 부담없이 사용한다.(JPA에서 @OptimisticLock 으로 쉽게 구현가능하다./ 그리고 두개의 Lock을 섞어서 사용 되기도 한다.)
하지만 분산 환경으로 가게 되면 비관적락을 간단하게 사용할수 없다.(로직에서 실수가 일어 날수있다.)
그래서 Optimistic Lock 추가적으로 적용해서 개발한다.